### PR TITLE
Use `--fail` flag when downloading the tar file

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -39,7 +39,7 @@ install_crystal() {
 
   (
     echo "∗ Downloading and installing Crystal..."
-    curl --silent --location --create-dirs --output "$source_path" "$download_url" || fail "Could not download Crystal $version"
+    curl --silent --fail --location --create-dirs --output "$source_path" "$download_url" || fail "Could not download Crystal $version"
     tar zxf "$source_path" -C "$install_path" --strip-components=1
     rm -rf "$tmp_download_dir"
     echo "The installation was successful!"


### PR DESCRIPTION
We don't want to erroneously allow a failed installation to result in a false-positive, i.e. asdf thinking the operation was successful. By adding the `--fail` flag, the curl operation will return a non-zero exit status, resulting in a failure that will invoke the `fail` function.

If we don't do this, even 404s or 500s will dump that error text into a file with a `.tar` extension that cannot be unpacked.

> tar: Error opening archive: Unrecognized archive format

---

Fixes #31 