### PR TITLE
Make libyaml dependency explicit

### DIFF
--- a/bin/help.deps
+++ b/bin/help.deps
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+print_deps() {
+  local platform
+
+  case "$OSTYPE" in
+    darwin*) platform="darwin" ;;
+    linux*) platform="linux" ;;
+  esac
+
+  if [ "$platform" == "darwin" ]; then
+    echo "DEPENDENCIES"
+    echo "libyaml (via Homebrew)"
+  fi
+}
+
+print_deps

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/bin/install
+++ b/bin/install
@@ -24,6 +24,16 @@ install_crystal() {
     *) fail "Unsupported platform" ;;
   esac
 
+  if [ "$platform" == "darwin" ]; then
+    if ! type brew >/dev/null 2>&1; then
+      fail "pre-built releases of Crystal depend on Homebrew. Visit https://brew.sh to install it."
+    fi
+
+    if ! [ -d "$(brew --prefix libyaml 2>/dev/null || true)" ]; then
+      fail "libyaml from Homebrew is required, run 'brew install libyaml'"
+    fi
+  fi
+
   local architecture
 
   case "$(uname -m)" in


### PR DESCRIPTION
It turns out the pre-built binaries for macOS depend on `libyaml` installed via Homebrew. This can verified using `otool`.

```console
$ otool -L shards
/Users/kevinsjoberg/.asdf/installs/crystal/1.0.0/embedded/bin/shards:
	/opt/crystal/embedded/lib/libyaml-0.2.dylib (compatibility version 3.0.0, current version 3.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
```

This dependency isn't noted, causing issues for people trying to run `shards` without having `libyaml` installed. See #14. I've tried to make this dependency more clear by introducing the following changes:

- Running `asdf help crystal` will print out the `libyaml` dependency on macOS
- Trying to install a Crystal version without having [Homebrew](http://brew.sh) installed causes an error
- Trying to install a Crystal version without having `libyaml` installed via Homebrew causes an error


**Homebrew not being installed**

```console
$ asdf install crystal 0.36.1
Fail: pre-built releases of Crystal depend on Homebrew. Visit https://brew.sh to install it.
````

**libyaml not being installed via Homebrew**

```console
$ asdf install crystal 0.36.1
Fail: libyaml from Homebrew is required, run 'brew install libyaml'
```