### PR TITLE
Rewrite dylib path for libyaml on macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -42,6 +42,16 @@ install_crystal() {
     curl --silent --fail --location --create-dirs --output "$source_path" "$download_url" || fail "Could not download Crystal $version"
     tar zxf "$source_path" -C "$install_path" --strip-components=1
     rm -rf "$tmp_download_dir"
+
+    if [ "$platform" == "darwin" ]; then
+      local libyaml_path
+      libyaml_path=$(otool -L "$install_path/embedded/bin/shards" | grep libyaml | cut -d " " -f1 | tr -d "\t")
+
+      if [ "$libyaml_path" == "/opt/crystal/embedded/lib/libyaml-0.2.dylib" ]; then
+        install_name_tool -change "$libyaml_path" "$install_path/embedded/lib/libyaml-0.2.dylib" "$install_path/embedded/bin/shards"
+      fi
+    fi
+
     echo "The installation was successful!"
   ) || (
     rm -rf "$install_path"


### PR DESCRIPTION
This pull request supersedes #39. On macOS we change the dylib path of libyaml to the correct location. By default, Crystal seem to expect that it was installed via Homebrew. As demonstrated by running on `shards`:

```console
$ otool -L shards
/opt/crystal/embedded/lib/libyaml-0.2.dylib (compatibility version 3.0.0, current version 3.4.0)
/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
```

`/opt/crystal` is the install location of Crystal when installed via `brew install crystal`. Since this plugin installs Crystal in a different location, we use update the dylib path accordingly.