### PR TITLE
Fix the color for error message

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 fail() {
-  echo -e "\e[31mFail:\e[m $*"
+  echo -e "\033[31mFail:\033[m $*"
   exit 1
 }
 


### PR DESCRIPTION
【Before】
[![Image from Gyazo](https://i.gyazo.com/9d5b46a95945cb1030c864745e28dd63.png)](https://gyazo.com/9d5b46a95945cb1030c864745e28dd63)

【After】
[![Image from Gyazo](https://i.gyazo.com/fb45c4506c60ec1aef23efed4488fec4.png)](https://gyazo.com/fb45c4506c60ec1aef23efed4488fec4)

MacOS Monterey 12.5.1 / zsh 5.8.1 (x86_64-apple-darwin21.0)