### PR TITLE
Add support to read the crystal version from `shard.yml` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ install & manage versions.
 
 ## Useful information
 
-asdf uses the `.tool-versions` for auto-switching between software versions. To
-ease migration, you can have it read `.crystal-version` file to find out what
-version of Crystal should be used. This only works with the exact version. To do
-this, add the following to `~/.asdfrc`:
+asdf uses the `.tool-versions` for auto-switching between software versions.
+If `legacy_verison_file` support is enabled, it can read the crystal version
+from `shard.yml`. To ease migration, it can also read the version from the
+`.crystal-version` file. This only works with the exact version.
+
+To enable `legacy_verison_file` support, add the following to `~/.asdfrc`:
 
 ```
 legacy_version_file = yes

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -3,3 +3,4 @@
 set -eo pipefail
 
 echo ".crystal-version"
+echo ".crystal-version shard.yml"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+get_legacy_version() {
+  current_file="$1"
+  basename="$(basename -- "$current_file")"
+
+  if [ "$basename" == "shard.yml" ]; then
+    CRYSTAL_VERSION="$(grep '^crystal:' "$current_file" |
+      sed 's/crystal:[[:space:]]*//g' |
+      head -1)"
+  elif [ "$basename" == ".crystal-version" ]; then
+    CRYSTAL_VERSION="$(cat "$current_file")"
+  fi
+
+  echo "$CRYSTAL_VERSION"
+}
+
+get_legacy_version "$1"


### PR DESCRIPTION
fixes #55 

Implemented similar to how asdf-ruby reads the version from Gemfile:
https://github.com/asdf-vm/asdf-ruby/blob/a1669a964c120bfd43f394564be63ff570c2ddb8/bin/parse-legacy-file