### PR TITLE
Fix add plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Installation
 
 ```
-asdf plugin-add crystal https://github.com/asdf-community/asdf-crystal.git
+asdf plugin add crystal https://github.com/asdf-community/asdf-crystal.git
 ```
 
 ## Usage


### PR DESCRIPTION
Small fix in the asdf plugin add command.
Tested on Ubuntu.

Similar change to the [PR](https://github.com/asdf-community/asdf-rust/pull/35) fixing the plugin add docs made in asdf-rust.